### PR TITLE
fix: missing install:deps for the checkout mfe

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Vite + Module Federation is now possible",
 	"main": "index.js",
 	"scripts": {
-		"install:deps": "pnpm --prefix ./host install && pnpm --prefix ./home install && pnpm --prefix ./home checkout",
+		"install:deps": "pnpm --prefix ./host install && pnpm --prefix ./home install && pnpm --prefix ./checkout install",
 		"dev": "run-p dev:*",
 		"dev:host": "pnpm --prefix ./host run dev",
 		"dev:home": "pnpm --prefix ./home run dev",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Vite + Module Federation is now possible",
 	"main": "index.js",
 	"scripts": {
-		"install:deps": "pnpm --prefix ./host install && pnpm --prefix ./home install",
+		"install:deps": "pnpm --prefix ./host install && pnpm --prefix ./home install && pnpm --prefix ./home checkout",
 		"dev": "run-p dev:*",
 		"dev:host": "pnpm --prefix ./host run dev",
 		"dev:home": "pnpm --prefix ./home run dev",


### PR DESCRIPTION
Fix installation otherwise a `pnpm dev` will fail.
Alternative migrate to pnpm workspace (monorepo), see request: https://github.com/gioboa/qwik-microfrontend-starter/pull/4
