### PR TITLE
fix: missing install for checkout and project name typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "react-microfrontend-demo",
+	"name": "qwik-microfrontends",
 	"version": "1.0.0",
 	"description": "Vite + Module Federation is now possible",
 	"main": "index.js",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"description": "Vite + Module Federation is now possible",
 	"main": "index.js",
 	"scripts": {
-		"install:deps": "pnpm --prefix ./host install && pnpm --prefix ./home install",
+		"install:deps": "pnpm --prefix ./host install && pnpm --prefix ./home install && pnpm --prefix ./checkout install",
 		"dev": "run-p dev:*",
 		"dev:host": "pnpm --prefix ./host run dev",
 		"dev:home": "pnpm --prefix ./home run dev",


### PR DESCRIPTION
- [x] Fix installation otherwise a pnpm dev will fail.
Alternative migrate to pnpm workspace (monorepo), see request: https://github.com/gioboa/qwik-microfrontend-starter/pull/4
- [x] Fix project name typo